### PR TITLE
Adds option to install salt development version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,9 @@ master : false
     Boolean whether or not you want to use a remote master. If set to false,
     make sure your minion config file has ``file_client: local`` set.
 
+salt_dev_version : false
+    Boolean. When set to ``true``, the latest development version of Salt will be installed to the box. When ``false``, it will use an existing version of Salt or download salt-minion from the PPA.
+
 salt_file_root_path : "salt/roots/salt"
     String path to your salt state tree. Only useful with ``master=false``.
 

--- a/lib/vagrant-salt/provisioner.rb
+++ b/lib/vagrant-salt/provisioner.rb
@@ -6,6 +6,7 @@ module VagrantSalt
       attr_accessor :minion_pub
       attr_accessor :master
       attr_accessor :run_highstate
+      attr_accessor :salt_dev_version
       attr_accessor :salt_file_root_path
       attr_accessor :salt_file_root_guest_path
       attr_accessor :salt_pillar_root_path
@@ -16,6 +17,7 @@ module VagrantSalt
       def minion_pub; @minion_pub || false; end
       def master; @master || false; end
       def run_highstate; @run_highstate || false; end
+      def salt_dev_version; @salt_dev_version || false; end
       def salt_file_root_path; @salt_file_root_path || "salt/roots/salt"; end
       def salt_file_root_guest_path; @salt_file_root_guest_path || "/srv/salt"; end
       def salt_pillar_root_path; @salt_pillar_root_path || "salt/roots/pillar"; end
@@ -94,6 +96,14 @@ module VagrantSalt
       env[:vm].channel.sudo("apt-get -q -y install salt-minion")
     end
 
+    def install_salt_dev
+      env[:ui].info "Installing salt development version."
+      env[:vm].channel.sudo("apt-get update")
+      env[:vm].channel.sudo("apt-get install -q -y python-setuptools python-m2crypto python-crypto python-yaml msgpack-python python-zmq")
+      env[:vm].channel.sudo("easy_install https://github.com/saltstack/salt/tarball/develop")
+      env[:vm].channel.sudo("mkdir -p /etc/salt")
+    end
+
     def accept_minion_key
       env[:ui].info "Accepting minion key."
       env[:vm].channel.sudo("salt-key -A")
@@ -129,6 +139,10 @@ module VagrantSalt
 
       if !config.master
         verify_shared_folders([config.salt_file_root_guest_path, config.salt_pillar_root_guest_path])
+      end
+
+      if config.salt_dev_version
+        install_salt_dev
       end
 
       if !salt_exists


### PR DESCRIPTION
Sometimes you need fixes that haven't been released yet. This let's you
install the latest development version from the GitHub tarball.

_Note:_ I'm not a Ruby dev and am new to Salt and Vagrant. I tested this against the official `precise32` box using a masterless setup and it works for me.
