### PR TITLE
Allow require salty-vagrant plugin directly in Vagrantfile

### DIFF
--- a/lib/vagrant-salt.rb
+++ b/lib/vagrant-salt.rb
@@ -1,4 +1,4 @@
 require "vagrant"
-require "vagrant-salt/provisioner"
+require_relative "vagrant-salt/provisioner"
 
 Vagrant.provisioners.register(:salt) { VagrantSalt::Provisioner }

--- a/scripts/bootstrap-salt-minion.sh
+++ b/scripts/bootstrap-salt-minion.sh
@@ -70,15 +70,18 @@ if [ "$UNAME" = "Linux" ] ; then
         fi
     elif [ -f /etc/debian_version ] ; then
         DVER=$(cat /etc/debian_version)
-        if [ $DVER = '6.0'  ]; then
-            log "Installing for Debian Squeeze."
-            do_with_root echo "deb http://backports.debian.org/debian-backports squeeze-backports main" >> /etc/apt/sources.list.d/backports.list
-            do_with_root apt-get update
-            do_with_root apt-get -t squeeze-backports -y install salt-minion
-        else
-            log "Debian version $VER not supported."
-            exit 1
-        fi
+        case "$DVER" in
+            6.0*)
+                log "Installing for Debian Squeeze."
+                do_with_root echo "deb http://backports.debian.org/debian-backports squeeze-backports main" >> /etc/apt/sources.list.d/backports.list
+                do_with_root apt-get update
+                do_with_root apt-get -t squeeze-backports -y install salt-minion
+                ;;
+            *)
+                log "Debian version $VER not supported."
+                exit 1
+                ;;
+        esac
     elif [ -f /etc/redhat-release ] ; then
         OS=$(cat /etc/redhat-release)
         CODENAME=$(cat /etc/redhat-release)


### PR DESCRIPTION
A relative require statement ensures the required file is included
correctly. For example, when the cwd is not in the lib directory. 
So, vagrant-salt may be required directly from the Vagrantfile. This
is necessary in some situation, like when the "vagrant-salt" gem can't
be installed. 

Specifically, I'm having trouble getting "vagrant gem install vagrant-salt"
to work on Windows. Has anyone got this working on cygwin? or, windows
in general? If so, how? 
If not,  I'll try to get it working using cygwin when I have more time,
and report back.
