### PR TITLE
improved lsb and develop support

### DIFF
--- a/scripts/bootstrap-salt-minion.sh
+++ b/scripts/bootstrap-salt-minion.sh
@@ -55,21 +55,16 @@ UNAME=`uname`
 if [ "$UNAME" != "Linux" ] ; then
     echo "Sorry, OS $UNAME is not supported."
     exit 1
-fi
-
-set -e
-trap "echo Installation failed." EXIT
-
-if [ "$UNAME" = "Linux" ] ; then
+else
+    set -e
+    trap "echo Installation failed." EXIT
  
-    if [ -f /etc/lsb-release ] ; then
+    if [ -f /etc/lsb-release ] || [ -f /usr/bin/lsb_release ]; then
         OS=$(lsb_release -si)
         CODENAME=$(lsb_release -sc)
-
     elif [ -f /etc/debian_version ] ; then
         OS=Debian
         CODENAME=$(cat /etc/debian_version)
-
     elif [ -f /etc/fedora-release ] ; then
         OS=Fedora
         CODENAME=$(cat /etc/fedora-release)
@@ -126,7 +121,7 @@ if [ "$UNAME" = "Linux" ] ; then
         if [ $CODENAME = 'wheezy' -o $CODENAME = 'jessie' ]; then
             echo "Installing for Debian Weezy/Jessie."
             apt-get -y install salt-minion
-        elif [ $CODENAME = '6.0'  ]; then
+        elif [ $CODENAME = 'squeeze'  ]; then
             echo "Installing for Debian Squeeze."
             echo "deb http://backports.debian.org/debian-backports squeeze-backports main" >> /etc/apt/sources.list.d/backports.list
             apt-get update
@@ -136,6 +131,17 @@ if [ "$UNAME" = "Linux" ] ; then
             exit 1
         fi
 
+        if [ $DEVELOP = 1 ]; then
+            rm -rf /usr/share/pyshared/salt*
+            rm -rf /usr/bin/salt-*
+            mkdir -p /root/git
+            rm -rf /root/git/salt
+            cd /root/git
+            git clone git://github.com/saltstack/salt.git
+            cd /root/git/salt
+            python setup.py install --install-layout=deb
+            cp conf/salt/minion.template /etc/salt/minion
+        fi
     elif [ $OS = 'Fedora' ] ; then
         if [ $DEVELOP = 1 ]; then
             yum install -y salt-minion git


### PR DESCRIPTION
I added a better check for Debian which allows the "squeeze" codename
to be used. Debian has "lsb_release" support built into a python module.

And, I added develop support for Debian.
