### PR TITLE
Add CentOS git install support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,10 +161,26 @@ salt_pillar_root_path : "salt/roots/pillar"
 salt_pillar_root_guest_path : "/srv/pillar"
     Path on VM where pillar tree will be shared. Only use with ``master=true``
 
+salt_nfs_shared_folders: true or false
+    Some vagrant machines do not support shared folders, for example, FreeBSD.
+    So, if you're running salty vagrant using a masterless setup, using an NFS 
+    share might be your only option. This option tries to make salty work with 
+    NFS. For more info, please check the Vagrant documentation regarding `NFS 
+    Shares`_.
+
+.. _NFS Shares: http://vagrantup.com/v1/docs/nfs.html
+
+
 Bootstrapping Salt
 ==================
 
-Before `Salt`_ can be used for provisioning on the target virtual box, the binaries need to be installed. Since `Vagrant`_ and `Salt`_ support many different distributions and versions of operating systems, the `Salt`_ installation process is handled by the shell script ``scripts/bootstrap-salt-minion.sh``. This script runs through a series of checks to determine operating system type and version to then install the `Salt`_ binaries using the appropriate methods.
+Before `Salt`_ can be used for provisioning on the target virtual box, the 
+binaries need to be installed. Since `Vagrant`_ and `Salt`_ support many 
+different distributions and versions of operating systems, the `Salt`_ 
+installation process is handled by the shell script 
+``scripts/bootstrap-salt-minion.sh``. This script runs through a series of 
+checks to determine operating system type and version to then install the 
+`Salt`_ binaries using the appropriate methods.
 
 Adding support for other operating systems
 ------------------------------------------
@@ -205,14 +221,19 @@ Below is an example for Ubuntu Oneiric:
         apt-get -y install salt-minion
     }
 
-Since there is no ``install_ubuntu_1110_stable()`` it defaults to the unspecified version script.
+Since there is no ``install_ubuntu_1110_stable()`` it defaults to the 
+unspecified version script.
 
-The bootstrapping script must be plain POSIX sh only, **not** bash or another shell script. By design the targeting for each operating system and version is very specific. Assumptions of supported versions or variants should not be made, to avoid failed or broken installations.
+The bootstrapping script must be plain POSIX sh only, **not** bash or another 
+shell script. By design the targeting for each operating system and version is 
+very specific. Assumptions of supported versions or variants should not be 
+made, to avoid failed or broken installations.
 
 Supported Operating Systems
 ---------------------------
 - Ubuntu 10.x/11.x/12.x
 - Debian 6.x
+- CentOS 6.3
 
 Installation Notes
 ==================
@@ -236,3 +257,5 @@ Installing from source
 3. ``cd saltstack-salty-vagrant-[hash]``
 4. ``gem build vagrant-salt.gemspec``
 5. ``vagrant gem install vagrant-salt-[version].gem``
+
+.. vim: fenc=utf-8 spell spl=en cc=80 tw=79 fo=want sts=2 sw=2 et

--- a/scripts/bootstrap-salt-minion.sh
+++ b/scripts/bootstrap-salt-minion.sh
@@ -571,25 +571,45 @@ install_arch_post() {
 #
 #   FreeBSD Install Functions
 #
-install_freebsd_stable_deps() {
+install_freebsd_9_stable_deps() {
+    if [ $CPU_VENDOR_ID_L = "AuthenticAMD" -a $CPU_ARCH_L = "x86_64" ]; then
+        local ARCH="amd64"
+    elif [ $CPU_VENDOR_ID_L = "GenuineIntel" -a $CPU_ARCH_L = "x86_64" ]; then
+        local ARCH="x86:64"
+    elif [ $CPU_VENDOR_ID_L = "GenuineIntel" -a $CPU_ARCH_L = "i386" ]; then
+        local ARCH="i386"
+    elif [ $CPU_VENDOR_ID_L = "GenuineIntel" -a $CPU_ARCH_L = "i686" ]; then
+        local ARCH="x86:32"
+    fi
+
     portsnap fetch extract update
     cd /usr/ports/ports-mgmt/pkg
     make install clean
     cd
     /usr/local/sbin/pkg2ng
-    echo 'PACKAGESITE: http://pkgbeta.freebsd.org/freebsd-9-amd64/latest' > /usr/local/etc/pkg.conf
+    echo 'PACKAGESITE: http://pkgbeta.freebsd.org/freebsd-9-${ARCH}/latest' > /usr/local/etc/pkg.conf
 }
 
 install_freebsd_git_deps() {
+    if [ $CPU_VENDOR_ID_L = "AuthenticAMD" -a $CPU_ARCH_L = "x86_64" ]; then
+        local ARCH="amd64"
+    elif [ $CPU_VENDOR_ID_L = "GenuineIntel" -a $CPU_ARCH_L = "x86_64" ]; then
+        local ARCH="x86:64"
+    elif [ $CPU_VENDOR_ID_L = "GenuineIntel" -a $CPU_ARCH_L = "i386" ]; then
+        local ARCH="i386"
+    elif [ $CPU_VENDOR_ID_L = "GenuineIntel" -a $CPU_ARCH_L = "i686" ]; then
+        local ARCH="x86:32"
+    fi
+
     portsnap fetch extract update
     cd /usr/ports/ports-mgmt/pkg
     make install clean
     cd
     /usr/local/sbin/pkg2ng
-    echo 'PACKAGESITE: http://pkgbeta.freebsd.org/freebsd-9-amd64/latest' > /usr/local/etc/pkg.conf
+    echo 'PACKAGESITE: http://pkgbeta.freebsd.org/freebsd-9-${ARCH}/latest' > /usr/local/etc/pkg.conf
 }
 
-install_freebsd_stable() {
+install_freebsd_9_stable() {
     pkg install -y salt
 }
 
@@ -604,7 +624,7 @@ install_freebsd_git() {
     /usr/local/bin/python setup.py install
 }
 
-install_freebsd_stable_post() {
+install_freebsd_9_stable_post() {
     salt-minion -d
 }
 
@@ -615,6 +635,7 @@ install_freebsd_git_post() {
 #   Ended FreeBSD Install Functions
 #
 ##############################################################################
+
 
 #=============================================================================
 # LET'S PROCEED WITH OUR INSTALLATION

--- a/scripts/bootstrap-salt-minion.sh
+++ b/scripts/bootstrap-salt-minion.sh
@@ -605,7 +605,7 @@ POST_FUNC_NAMES="$POST_FUNC_NAMES install_${DISTRO_NAME_L}_post"
 POST_INSTALL_FUNC="null"
 for FUNC_NAME in $POST_FUNC_NAMES; do
     if __function_defined $FUNC_NAME; then
-        DEPS_INSTALL_FUNC=$FUNC_NAME
+        POST_INSTALL_FUNC=$FUNC_NAME
         break
     fi
 done

--- a/scripts/bootstrap-salt-minion.sh
+++ b/scripts/bootstrap-salt-minion.sh
@@ -449,7 +449,6 @@ install_fedora_stable() {
 #
 #   CentOS Install Functions
 #
-
 install_centos_63_stable_deps() {
     if [ $CPU_ARCH_L = "i686" ]; then
         local ARCH="i386"
@@ -466,7 +465,33 @@ install_centos_63_stable() {
 
 install_centos_63_stable_post() {
     /sbin/chkconfig salt-minion on
+    #/etc/init.d/salt-minion start &
     salt-minion start &
+}
+
+install_centos_63_git_deps() {
+    install_centos_63_stable_deps
+    yum -y install git PyYAML m2crypto python-crypto python-msgpack python-zmq python-jinja2 --enablerepo=epel-testing
+}
+
+install_centos_63_git() {
+    rm -rf /usr/lib/python*/site-packages/salt
+    rm -rf /usr/bin/salt*
+    cd /tmp
+    git clone git://github.com/saltstack/salt.git
+    cd salt
+    git checkout $GIT_REV
+    python2 setup.py install
+    mkdir -p /etc/salt/
+
+}
+
+install_centos_63_git_post() {
+    cp pkg/rpm/salt-{master,minion} /etc/init.d/
+    chmod +x /etc/init.d/salt-{master,minion}
+    /sbin/chkconfig salt-minion on
+    /etc/init.d/salt-minion start &
+    sleep 1
 }
 #
 #   Ended CentOS Install Functions
@@ -638,3 +663,4 @@ fi
 
 # Done!
 echo " * Salt installed!"
+exit 0


### PR DESCRIPTION
Although this adds CentOS git install support, there's something wrong with both git and stable installations, there's no "next" step once installed.

For stable:

```
Installed:
  salt-minion.noarch 0:0.10.3-1.el6                                             

Dependency Installed:
  PyYAML.i686 0:3.10-3.el6                                                      
  libyaml.i686 0:0.1.3-1.el6                                                    
  m2crypto.i686 0:0.20.2-9.el6                                                  
  python-babel.noarch 0:0.9.4-5.1.el6                                           
  python-crypto.i686 0:2.0.1-22.el6                                             
  python-jinja2.i686 0:2.2.1-1.el6                                              
  python-msgpack.i686 0:0.1.9-2.el6                                             
  python-zmq.i686 0:2.2.0-4.el6                                                 
  salt.noarch 0:0.10.3-1.el6                                                    
  zeromq3.i686 0:3.2.0-0.3.20121009git1ef63bc.el6
[default] Complete!
[default]  * Running install_centos_63_stable_post()
[default]  * Salt installed!
[default] [WARNING ] Setting up the Salt Minion "localhost.localdomain"
[default] [ERROR   ] This master address: 'salt' was previously resolvable but now fails to resolve! The previously resolved ip addr will continue to be used
[default] [ERROR   ] This master address: 'salt' was previously resolvable but now fails to resolve! The previously resolved ip addr will continue to be used
[default] [ERROR   ] This master address: 'salt' was previously resolvable but now fails to resolve! The previously resolved ip addr will continue to be used
```

For git:

```
[default] changing mode of /usr/bin/salt-call to 755
[default] running install_data
[default] copying doc/man/salt-master.1 -> /usr/share/man/man1
[default] copying doc/man/salt-key.1 -> /usr/share/man/man1
[default] copying doc/man/salt.1 -> /usr/share/man/man1
[default] copying doc/man/salt-cp.1 -> /usr/share/man/man1
[default] copying doc/man/salt-call.1 -> /usr/share/man/man1
[default] copying doc/man/salt-syndic.1 -> /usr/share/man/man1
[default] copying doc/man/salt-run.1 -> /usr/share/man/man1
[default] copying doc/man/salt-minion.1 -> /usr/share/man/man1
[default] copying doc/man/salt.7 -> /usr/share/man/man7
[default] running install_egg_info
[default] Writing /usr/lib/python2.6/site-packages/salt-0.10.3-py2.6.egg-info
[default]  * Running install_centos_63_git_post()
[default] Starting salt-minion daemon:
[default]  * Salt installed!
[default] [  OK  ]
```

They both reach the `* Salt installed!` point, so, the whole script was executed. Dunno what's happening. I'll update my CentOS vagrant image once I get home and retry.
