### PR TITLE
Fix checking whether there is an installation function.

### DIFF
--- a/scripts/bootstrap-salt-minion.sh
+++ b/scripts/bootstrap-salt-minion.sh
@@ -787,7 +787,7 @@ if [ $DEPS_INSTALL_FUNC = "null" ]; then
     exit 1
 fi
 
-if [ $DEPS_INSTALL_FUNC = "null" ]; then
+if [ $INSTALL_FUNC = "null" ]; then
     echo " * ERROR: No installation function found. Exiting..."
     exit 1
 fi


### PR DESCRIPTION
For some reason there is no installation function found on Ubuntu 12.04 LTS
(precise64 from http://files.vagrantup.com/precise64.box). While that is a
problem in itself, the bug that is fixed in this commit is triggered because of
that.
