### PR TITLE
Add salt-cloud support.

### DIFF
--- a/scripts/bootstrap-salt-minion.sh
+++ b/scripts/bootstrap-salt-minion.sh
@@ -61,7 +61,7 @@ do
     h|help          )  usage; exit 0   ;;
 
     v|version       )  echo "$0 -- Version $ScriptVersion"; exit 0   ;;
-    c|config-dir    )  TEMP_CONFIG_DIR=$OPTARG ;;
+    c|config-dir    )  TEMP_CONFIG_DIR="$OPTARG" ;;
 
     \? )  echo "\n  Option does not exist : $OPTARG\n"
           usage; exit 1   ;;
@@ -87,7 +87,7 @@ if [ $ITYPE = "git" ]; then
     if [ "$#" -eq 0 ];then
         GIT_REV="master"
     else
-        GIT_REV=$1
+        GIT_REV="$1"
         shift
     fi
 fi
@@ -843,6 +843,7 @@ done
 
 
 # Let's get the minion config function
+CONFIG_MINION_FUNC="null"
 if [ "$TEMP_CONFIG_DIR" != "null" ]; then
     CONFIG_FUNC_NAMES="config_${DISTRO_NAME_L}${DISTRO_VERSION_NO_DOTS}_${ITYPE}_minion"
     CONFIG_FUNC_NAMES="$CONFIG_FUNC_NAMES config_${DISTRO_NAME_L}${DISTRO_VERSION_NO_DOTS}_minon"
@@ -850,7 +851,6 @@ if [ "$TEMP_CONFIG_DIR" != "null" ]; then
     CONFIG_FUNC_NAMES="$CONFIG_FUNC_NAMES config_${DISTRO_NAME_L}_minion"
     CONFIG_FUNC_NAMES="$CONFIG_FUNC_NAMES config_minion"
 
-    CONFIG_MINION_FUNC="null"
     for FUNC_NAME in $CONFIG_FUNC_NAMES; do
         if __function_defined $FUNC_NAME; then
             CONFIG_MINION_FUNC=$FUNC_NAME

--- a/scripts/bootstrap-salt-minion.sh
+++ b/scripts/bootstrap-salt-minion.sh
@@ -398,10 +398,17 @@ __apt_get_noinput() {
 #
 #   To install salt, which, of course, is required, one of:
 #       1. install_<distro>_<distro_version>_<install_type>
-#       1. install_<distro>_<install_type>
+#       2. install_<distro>_<install_type>
 #
+#   Optionally, define a minion configuration function, which will be called if
+#   the -c|config-dir option is passed. One of:
+#       1. config_<distro>_<distro_version>_<install_type>_minion
+#       2. config_<distro>_<distro_version>_minion
+#       3. config_<distro>_<install_type>_minion
+#       4. config_<distro>_minion
+#       5. config_minion [THIS ONE IS ALREADY DEFINED AS THE DEFAULT]
 #
-#   And optionally, define a post install function, one of:
+#   Also optionally, define a post install function, one of:
 #       1. install_<distro>_<distro_versions>_<install_type>_post
 #       2. install_<distro>_<distro_versions>_post
 #       3. install_<distro>_<install_type>_post

--- a/scripts/bootstrap-salt-minion.sh
+++ b/scripts/bootstrap-salt-minion.sh
@@ -52,6 +52,7 @@ EOT
 #-----------------------------------------------------------------------
 #  Handle command line arguments
 #-----------------------------------------------------------------------
+TEMP_CONFIG_DIR="null"
 
 while getopts ":hvc:" opt
 do
@@ -60,7 +61,7 @@ do
     h|help          )  usage; exit 0   ;;
 
     v|version       )  echo "$0 -- Version $ScriptVersion"; exit 0   ;;
-    c|config-dir    )  CONFIG_DIR=$OPTARG ;;
+    c|config-dir    )  TEMP_CONFIG_DIR=$OPTARG ;;
 
     \? )  echo "\n  Option does not exist : $OPTARG\n"
           usage; exit 1   ;;
@@ -759,10 +760,10 @@ install_freebsd_git_post() {
 #
 config_minion() {
     # If the configuration directory is not passed, return
-    [ -z "$CONFIG_DIR" ] && return
+    [ "$TEMP_CONFIG_DIR" = "null" ] && return
     # If the configuration directory does not exist, error out
-    if [ ! -d "$CONFIG_DIR" ]; then
-        echo " * The configuration directory ${CONFIG_DIR} does not exist."
+    if [ ! -d "$TEMP_CONFIG_DIR" ]; then
+        echo " * The configuration directory ${TEMP_CONFIG_DIR} does not exist."
         exit 1
     fi
 
@@ -771,15 +772,15 @@ config_minion() {
     [ -d /etc/salt/pki ] || mkdir /etc/salt/pki && chmod 700 /etc/salt/pki
 
     # Copy the minions configuration if found
-    [ -f "$CONFIG_DIR/minion" ] && mv "$CONFIG_DIR/minion" /etc/salt
+    [ -f "$TEMP_CONFIG_DIR/minion" ] && mv "$TEMP_CONFIG_DIR/minion" /etc/salt
 
     # Copy the minion's keys if found
-    if [ -f "$CONFIG_DIR/minion.pem" ]; then
-        mv "$CONFIG_DIR/minion.pem" /etc/salt/pki
+    if [ -f "$TEMP_CONFIG_DIR/minion.pem" ]; then
+        mv "$TEMP_CONFIG_DIR/minion.pem" /etc/salt/pki
         chmod 400 /etc/salt/pki/minion.pem
     fi
-    if [ -f "$CONFIG_DIR/minion.pub" ]; then
-        mv "$CONFIG_DIR/minion.pub" /etc/salt/pki
+    if [ -f "$TEMP_CONFIG_DIR/minion.pub" ]; then
+        mv "$TEMP_CONFIG_DIR/minion.pub" /etc/salt/pki
         chmod 664 /etc/salt/pki/minion.pub
     fi
 }
@@ -822,7 +823,7 @@ done
 
 
 # Let's get the minion config function
-if [ "x$CONFIG_DIR"!= "x" ]; then
+if [ "$TEMP_CONFIG_DIR" != "null" ]; then
     CONFIG_FUNC_NAMES="config_${DISTRO_NAME_L}${DISTRO_VERSION_NO_DOTS}_${ITYPE}_minion"
     CONFIG_FUNC_NAMES="$CONFIG_FUNC_NAMES config_${DISTRO_NAME_L}${DISTRO_VERSION_NO_DOTS}_minon"
     CONFIG_FUNC_NAMES="$CONFIG_FUNC_NAMES config_${DISTRO_NAME_L}_${ITYPE}_minion"
@@ -882,7 +883,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Configure Salt
-if [ "x$CONFIG_DIR"!= "x" -a "$CONFIG_MINION_FUNC" != "null" ]; then
+if [ "$TEMP_CONFIG_DIR" != "null" -a "$CONFIG_MINION_FUNC" != "null" ]; then
     echo " * Running ${CONFIG_MINION_FUNC}()"
     $CONFIG_MINION_FUNC
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
- Added the `-c|config-dir` option which should point to a temporary directory which should contain the minion's config and keys. If these are found, they're moved to the proper place.
- Added the default `minion_config` function which should work for most cases. Those that have special needs can provide their own config function which is searched in the following order:
  1. `config_<distro>_<distro_version>_<install_type>_minion`
  2. `config_<distro>_<distro_version>_minion`
  3. `config_<distro>_<install_type>_minion`
  4. `config_<distro>_minion`
  5. `config_minion`
