### PR TITLE
Accept Keys if configured from master config

### DIFF
--- a/lib/vagrant-salt/config.rb
+++ b/lib/vagrant-salt/config.rb
@@ -1,5 +1,6 @@
 require "i18n"
 require "vagrant"
+require "yaml"
 
 module VagrantPlugins
   module Salt
@@ -90,8 +91,15 @@ module VagrantPlugins
           errors << I18n.t("salt.accept_key_no_master")
         end
 
-        if @install_master && !@no_minion && !@accept_keys && @run_highstate
-          errors << I18n.t("salt.must_accept_keys")
+        if @install_master && !@no_minion && @run_highstate
+          if @master_config
+            master_config = YAML::load_file(@master_config)
+            if !master_config["auto_accept"] && !@accept_keys
+              errors << I18n.t("salt.must_accept_keys")
+            end
+          elsif !@accept_keys
+            errors << I18n.t("salt.must_accept_keys")
+          end
         end
 
         return {"salt" => errors}

--- a/lib/vagrant-salt/provisioner.rb
+++ b/lib/vagrant-salt/provisioner.rb
@@ -97,7 +97,7 @@ module VagrantPlugins
 
           if @config.install_args
             options = "%s %s" % [options, @config.install_args]
-          end 
+          end
         end
         if @config.verbose
           @machine.env.ui.info "Using Bootstrap Options: %s" % options
@@ -159,7 +159,7 @@ module VagrantPlugins
           else
             @machine.env.ui.info "Bootstrapping Salt... (this may take a while)"
           end
-          
+
           bootstrap_path = get_bootstrap()
           bootstrap_destination = File.join(config_dir, "bootstrap_salt.sh")
           @machine.communicate.upload(bootstrap_path.to_s, bootstrap_destination)
@@ -185,7 +185,7 @@ module VagrantPlugins
           elsif !configure and install
             @machine.env.ui.info "Salt successfully installed!"
           end
-        
+
         else
           @machine.env.ui.info "Salt did not need installing or configuring."
         end
@@ -199,8 +199,17 @@ module VagrantPlugins
             @machine.env.ui.info "Waiting for minion key..."
             key_staged = false
             attempts = 0
+            @machine.communicate.sudo("salt-key -l acc | wc -l") do |type, output|
+              begin
+                output = Integer(output)
+                if output > 1
+                  key_staged = true
+                end
+              rescue
+              end
+            end
             while !key_staged
-              attempts += 1 
+              attempts += 1
               @machine.communicate.sudo("salt-key -l pre | wc -l") do |type, output|
                 begin
                   output = Integer(output)


### PR DESCRIPTION
If a install_master is set and a master_config is provided, read that file and test for auto_accept: True. If this setting is present the Vagrantfile will not require:

``` ruby
config.vm.provision :salt do |salt|
  salt.accept_keys = true
end
```

as the master config effectively does the same thing.
