### PR TITLE
Add 'seed_master' feature and flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ run_highstate    (true/false)
     Executes ``state.highstate`` on vagrant up
 
 accept_keys      (true/false)
-    Accept all keys if running a master
+    Accept all keys if running a master. DEPRECATED: use `seed_master`
 
 
 Install Options
@@ -119,6 +119,10 @@ master_key       (salt/key/master.pem)
 
 master_pub       (salt/key/master.pub)
   Path to your master public key
+
+seed_master  {minion_name:/path/to/key.pub}
+  Upload keys to master, thereby pre-seeding it
+  before use.
 
 
 Other

--- a/example/complete/Vagrantfile
+++ b/example/complete/Vagrantfile
@@ -34,6 +34,9 @@ Vagrant.configure("2") do |config|
     # Install a master on this machine
     salt.install_master = true
 
+    # Pre-seed your master (recommended)
+    salt.seed_master = {minion: salt.minion_pub}
+
     # Can also install syndic:
     # salt.install_syndic = true
 
@@ -44,7 +47,9 @@ Vagrant.configure("2") do |config|
     # Normally we want to run state.highstate to provision the machine
     salt.run_highstate = true
 
-    # If you are using a master with minion setup, you need to accept keys
+    # If you are using a master with minion setup, you may accept keys
+    # If keys have already been except, it will pass
+    # DEPRECATED
     salt.accept_keys = true
 
     # Default will not install / update salt binaries if they are present

--- a/lib/vagrant-salt/config.rb
+++ b/lib/vagrant-salt/config.rb
@@ -17,6 +17,7 @@ module VagrantPlugins
       attr_accessor :accept_keys
       attr_accessor :bootstrap_script
       attr_accessor :verbose
+      attr_accessor :seed_master
 
       ## bootstrap options
       attr_accessor :temp_config_dir
@@ -39,6 +40,7 @@ module VagrantPlugins
         @accept_keys = UNSET_VALUE
         @bootstrap_script = UNSET_VALUE
         @verbose = UNSET_VALUE
+        @seed_master = UNSET_VALUE
         @temp_config_dir = UNSET_VALUE
         @install_type = UNSET_VALUE
         @install_args = UNSET_VALUE
@@ -60,6 +62,7 @@ module VagrantPlugins
         @accept_keys        = nil if @accept_keys == UNSET_VALUE
         @bootstrap_script   = nil if @bootstrap_script == UNSET_VALUE
         @verbose            = nil if @verbose == UNSET_VALUE
+        @seed_master           = nil if @seed_master == UNSET_VALUE
         @temp_config_dir    = nil if @temp_config_dir == UNSET_VALUE
         @install_type       = nil if @install_type == UNSET_VALUE
         @install_args       = nil if @install_args == UNSET_VALUE

--- a/lib/vagrant-salt/config.rb
+++ b/lib/vagrant-salt/config.rb
@@ -62,7 +62,7 @@ module VagrantPlugins
         @accept_keys        = nil if @accept_keys == UNSET_VALUE
         @bootstrap_script   = nil if @bootstrap_script == UNSET_VALUE
         @verbose            = nil if @verbose == UNSET_VALUE
-        @seed_master           = nil if @seed_master == UNSET_VALUE
+        @seed_master        = nil if @seed_master == UNSET_VALUE
         @temp_config_dir    = nil if @temp_config_dir == UNSET_VALUE
         @install_type       = nil if @install_type == UNSET_VALUE
         @install_args       = nil if @install_args == UNSET_VALUE
@@ -93,7 +93,7 @@ module VagrantPlugins
           errors << I18n.t("salt.accept_key_no_master")
         end
 
-        if @install_master && !@no_minion && !@accept_keys && @run_highstate
+        if @install_master && !@no_minion && !@accept_keys && !@seed_master && @run_highstate
           errors << I18n.t("salt.must_accept_keys")
         end
 


### PR DESCRIPTION
Adding 'seed_master' feature to supersede 'accept_keys'.

Flag is defined as so:

``` ruby
salt.install_master = true
salt.seed_master = {minion: "salt/key/minion.pub"}
```

After bootstrap, the provisioner will check for un-accepted keys and then accept by name or 
upload any key defined in `salt.seed_master` to /etc/salt/pki/master/minions/.   

I made some minor changes to `salt.accept_keys` also:
- if keys are found in the master, it skips accepting keys.  This allows for repeated runs of `vagrant provision`
- a deprecation warning informs user of `salt.seed_master`
