### PR TITLE
Pillar data export

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,9 +172,9 @@ Miscellaneous
 Pillar Data
 -----------
 
-You can export pillar data for use during provisioning by using the ``pillar``
-command. Each call will merge the data so you can safely call it multiple
-times.  Here is an example::
+You can export pillar data for use during provisioning by using the ``pillar`` 
+command. Each call will merge the data so you can safely call it multiple 
+times. The data passed in should only be hashes and lists. Here is an example::
 
       config.vm.provision :salt do |salt|
 

--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,10 @@ temp_config_dir  (/tmp)
     Path on the guest box that config and bootstrap files will be copied 
     to before placing in the salt directories
 
+pillar_data
+    Get pillar data that has been set (this is read only because data
+    should be set using the ``pillar`` command referenced below)
+
 verbose          (true/false)
     Prints bootstrap script output to screen
 
@@ -164,6 +168,37 @@ Installing from source
 
 Miscellaneous
 =============
+
+Pillar Data
+-----------
+
+You can export pillar data for use during provisioning by using the ``pillar``
+command. Each call will merge the data so you can safely call it multiple
+times.  Here is an example:
+
+```ruby
+      config.vm.provision :salt do |salt|
+
+        # Export hostnames for webserver config
+        salt.pillar({
+          "hostnames" => {
+            "www" => "www.example.com",
+            "intranet" => "intranet.example.com"
+          }
+        })
+
+        # Export database credentials
+        salt.pillar({
+          "database" => {
+            "user" => "jdoe",
+            "password" => "topsecret"
+          }
+        })
+
+        salt.run_highstate = true
+
+      end
+```
 
 Using Remote Salt Master
 ------------------------

--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,7 @@ Pillar Data
 
 You can export pillar data for use during provisioning by using the ``pillar``
 command. Each call will merge the data so you can safely call it multiple
-times.  Here is an example:
+times.  Here is an example::
 
       config.vm.provision :salt do |salt|
 

--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,6 @@ You can export pillar data for use during provisioning by using the ``pillar``
 command. Each call will merge the data so you can safely call it multiple
 times.  Here is an example:
 
-```ruby
       config.vm.provision :salt do |salt|
 
         # Export hostnames for webserver config
@@ -198,7 +197,6 @@ times.  Here is an example:
         salt.run_highstate = true
 
       end
-```
 
 Using Remote Salt Master
 ------------------------

--- a/lib/vagrant-salt/config.rb
+++ b/lib/vagrant-salt/config.rb
@@ -18,7 +18,6 @@ module VagrantPlugins
       attr_accessor :bootstrap_script
       attr_accessor :verbose
       attr_accessor :seed_master
-      attr_accessor :pillar_root
       attr_reader   :pillar_data
 
       ## bootstrap options
@@ -43,7 +42,6 @@ module VagrantPlugins
         @bootstrap_script = UNSET_VALUE
         @verbose = UNSET_VALUE
         @seed_master = UNSET_VALUE
-        @pillar_root = UNSET_VALUE
         @pillar_data = UNSET_VALUE
         @temp_config_dir = UNSET_VALUE
         @install_type = UNSET_VALUE
@@ -67,7 +65,6 @@ module VagrantPlugins
         @bootstrap_script   = nil if @bootstrap_script == UNSET_VALUE
         @verbose            = nil if @verbose == UNSET_VALUE
         @seed_master        = nil if @seed_master == UNSET_VALUE
-        @pillar_root        = nil if @pillar_root == UNSET_VALUE
         @pillar_data        = nil if @pillar_data == UNSET_VALUE
         @temp_config_dir    = nil if @temp_config_dir == UNSET_VALUE
         @install_type       = nil if @install_type == UNSET_VALUE
@@ -79,11 +76,9 @@ module VagrantPlugins
 
       end
 
-      def pillar(name, data)
-        if !@pillar_data.is_a?(Hash)
-          @pillar_data = {}
-        end
-        @pillar_data.has_key?(name) ? @pillar_data[name].deep_merge!(data) : @pillar_data[name] = data
+      def pillar(data)
+        @pillar_data = {} if @pillar_data == UNSET_VALUE
+        @pillar_data.deep_merge!(data)
       end
 
       def validate(machine)

--- a/lib/vagrant-salt/config.rb
+++ b/lib/vagrant-salt/config.rb
@@ -18,6 +18,8 @@ module VagrantPlugins
       attr_accessor :bootstrap_script
       attr_accessor :verbose
       attr_accessor :seed_master
+      attr_accessor :pillar_root
+      attr_reader   :pillar_data
 
       ## bootstrap options
       attr_accessor :temp_config_dir
@@ -41,6 +43,8 @@ module VagrantPlugins
         @bootstrap_script = UNSET_VALUE
         @verbose = UNSET_VALUE
         @seed_master = UNSET_VALUE
+        @pillar_root = UNSET_VALUE
+        @pillar_data = UNSET_VALUE
         @temp_config_dir = UNSET_VALUE
         @install_type = UNSET_VALUE
         @install_args = UNSET_VALUE
@@ -63,6 +67,8 @@ module VagrantPlugins
         @bootstrap_script   = nil if @bootstrap_script == UNSET_VALUE
         @verbose            = nil if @verbose == UNSET_VALUE
         @seed_master        = nil if @seed_master == UNSET_VALUE
+        @pillar_root        = nil if @pillar_root == UNSET_VALUE
+        @pillar_data        = nil if @pillar_data == UNSET_VALUE
         @temp_config_dir    = nil if @temp_config_dir == UNSET_VALUE
         @install_type       = nil if @install_type == UNSET_VALUE
         @install_args       = nil if @install_args == UNSET_VALUE
@@ -71,6 +77,13 @@ module VagrantPlugins
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
 
+      end
+
+      def pillar(name, data)
+        if !@pillar_data.is_a?(Hash)
+          @pillar_data = {}
+        end
+        @pillar_data.has_key?(name) ? @pillar_data[name].deep_merge!(data) : @pillar_data[name] = data
       end
 
       def validate(machine)

--- a/lib/vagrant-salt/provisioner.rb
+++ b/lib/vagrant-salt/provisioner.rb
@@ -188,7 +188,7 @@ module VagrantPlugins
 
         # Write out each pillar file and save top.sls changes
         @config.pillar_data.each_with_index do |(file, data), idx|
-          @machine.env.ui.info "Generating Pillar data in #{file}.sls..."
+          @machine.env.ui.info "[salt:pillar] Generating data in #{file}.sls..."
 
           top['base'][minion].is_a?(Array) ?
             top['base'][minion] |= ["_gen/#{file}"] :
@@ -201,7 +201,7 @@ module VagrantPlugins
 
           # Write changes to top.sls if needed
           if idx == @config.pillar_data.size - 1
-            @machine.env.ui.info "Updating top.sls for Pillar..."
+            @machine.env.ui.info "[salt:pillar] Updating top.sls..."
             File.open(File.join(root, "top.sls"), "w") do |f|
               f.write(cleanyaml[top])
             end


### PR DESCRIPTION
I wanted an easy way to pass data from my Vagrantfile into pillar so I created my own custom plugin at one point.  I rewrote the code with several improvements and integrated it into salty-vagrant because it just seemed like it belongs here.  There is a **pillar_root** option to specify the path to your pillar root and usage is pretty simple:

```
config.vm.provision :salt do |salt|
  salt.pillar(:hosts, {
    "hostnames" => {
      "www" => "www.example.com",
      "intranet" => "intranet.example.com"
    }
  })

  salt.run_highstate = true
end
```

This will create the file _{pillar_root}_ **/_gen/hosts.sls** with the following contents:

```
hostnames:
  www: www.example.com
  intranet: intranet.example.com
```

Additionally, _{pillar_root}_ **/top.sls** will be modified so that it pulls in the generated file:

```
base:
  '*':
    - _gen/hosts
```

I welcome any and all constructive feedback and would love to see this incorporated in the next released version or so.  If there would be a better way to implement any of this or some use cases I need to consider please discuss.
