### PR TITLE
Fixing null access off get_pillar

### DIFF
--- a/lib/vagrant-salt/config.rb
+++ b/lib/vagrant-salt/config.rb
@@ -64,7 +64,7 @@ module VagrantPlugins
         @accept_keys        = nil if @accept_keys == UNSET_VALUE
         @bootstrap_script   = nil if @bootstrap_script == UNSET_VALUE
         @verbose            = nil if @verbose == UNSET_VALUE
-        @seed_master        = nil if @seed_master == UNSET_VALUE
+        @seed_master        = {}  if @seed_master == UNSET_VALUE
         @pillar_data        = nil if @pillar_data == UNSET_VALUE
         @temp_config_dir    = nil if @temp_config_dir == UNSET_VALUE
         @install_type       = nil if @install_type == UNSET_VALUE


### PR DESCRIPTION
Currently if pillar_data is not set the plugin this does not work and throws error outlined in https://github.com/saltstack/salty-vagrant/issues/78

This is due to the api trying to access an initialized get_pillar
