### PR TITLE
Added possibility to define minion and master configuration files variab...

### DIFF
--- a/lib/vagrant-salt/config.rb
+++ b/lib/vagrant-salt/config.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
       attr_accessor :verbose
       attr_accessor :seed_master
       attr_reader   :pillar_data
+      attr_accessor :template_values
 
       ## bootstrap options
       attr_accessor :temp_config_dir
@@ -50,6 +51,7 @@ module VagrantPlugins
         @install_syndic = UNSET_VALUE
         @no_minion = UNSET_VALUE
         @bootstrap_options = UNSET_VALUE
+        @template_values = UNSET_VALUE
       end
 
       def finalize!
@@ -73,7 +75,7 @@ module VagrantPlugins
         @install_syndic     = nil if @install_syndic == UNSET_VALUE
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
-
+        @template_values    = nil if @template_values == UNSET_VALUE
       end
 
       def pillar(data)
@@ -90,7 +92,7 @@ module VagrantPlugins
         end
 
         if @master_key && @master_pub
-          if !@minion_key && !@minion_pub
+          if !@no_minion && !@minion_key && !@minion_pub
             errors << I18n.t("salt.missing_key")
           end
         end

--- a/lib/vagrant-salt/config.rb
+++ b/lib/vagrant-salt/config.rb
@@ -20,6 +20,7 @@ module VagrantPlugins
       attr_accessor :seed_master
       attr_reader   :pillar_data
       attr_accessor :template_values
+      attr_accessor :seed_dir
 
       ## bootstrap options
       attr_accessor :temp_config_dir
@@ -52,6 +53,7 @@ module VagrantPlugins
         @no_minion = UNSET_VALUE
         @bootstrap_options = UNSET_VALUE
         @template_values = UNSET_VALUE
+        @seed_dir = UNSET_VALUE
       end
 
       def finalize!
@@ -76,6 +78,7 @@ module VagrantPlugins
         @no_minion          = nil if @no_minion == UNSET_VALUE
         @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
         @template_values    = nil if @template_values == UNSET_VALUE
+        @seed_dir           = nil if @seed_dir == UNSET_VALUE
       end
 
       def pillar(data)


### PR DESCRIPTION
Added possibility to define minion and master configuration variables during deployment from Vagrantfile. For example if you want to deploy master and minion on separate nodes you can define minion.erb template where master variable is defined like 

```
master: <%= template_values['master'] %>
```

and in Vagrantfile you can write something like this

```
config.vm.provision :salt do |salt|
     salt.minion_config = "salt/minion.erb"
     salt.template_values = {
       "master" => "a.b.c.d"
     }
```
