### PR TITLE
Fixed preseeded key file name

### DIFF
--- a/lib/vagrant-salt/provisioner.rb
+++ b/lib/vagrant-salt/provisioner.rb
@@ -119,10 +119,10 @@ module VagrantPlugins
           @machine.communicate.sudo("mkdir -p -m777 #{seed_dir}")
           @config.seed_master.each do |name, keyfile|
             sourcepath = expanded_path(keyfile).to_s
-            dest = "#{seed_dir}/seed-#{name}.pub"
-            @machine.communicate.upload(sourcepath, dest)   
+            dest = "#{seed_dir}/#{name}"
+            @machine.communicate.upload(sourcepath, dest)
           end
-          options = "#{options} -k #{seed_dir}" 
+          options = "#{options} -k #{seed_dir}"
         end
 
         if configure and !install


### PR DESCRIPTION
The preseeded keys use a name format ("seed-#{name}.pub") that is not suitable with latest bootstrap script (1.5.5). This pull request fixes that problem by simply naming keys after the names given in the seed_master configuration values.  
